### PR TITLE
Add Express hello world app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
-#start
-1
-2
-3
-4
-5
-#end
-s
-as
+# Node Hello World
 
+This repository contains a minimal [Express](https://expressjs.com/) application that responds with `Hello, World!`.
 
-as
+## Setup
 
-ads
+```bash
+npm install
+npm start
+```
 
-ads
+The application will be available at <http://localhost:3000>.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-hello-world",
+  "version": "1.0.0",
+  "description": "Sample Express Hello World app",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node server.js & pid=$!; sleep 1; kill $pid"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,10 +1,13 @@
-var http = require('http');
-http.createServer(function (req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
-  res.end('Hello 5!!!!\n');
-}).listen(80);
-console.log('Server running at Anand!');
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
 
-for (var i = 0; i < 10000; i++) {
-  console.log(i)
-}
+app.get('/', (req, res) => {
+  res.send('Hello, World!');
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- use Express to serve `Hello, World!`
- define package and npm scripts
- document installation and startup instructions

## Testing
- `npm install` *(fails: 403 Forbidden to https://registry.npmjs.org/express)*
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_6892023880a8832bbb010313dad425a6