### PR TITLE
Use disk storage and limit upload size

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const multer = require('multer');
+const fs = require('fs');
+const os = require('os');
 const {
   S3Client,
   PutObjectCommand,
@@ -9,7 +11,15 @@ const {
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 
 const app = express();
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: os.tmpdir(),
+    filename: (req, file, cb) => cb(null, file.originalname)
+  }),
+  limits: {
+    fileSize: parseInt(process.env.MAX_FILE_SIZE || '52428800', 10)
+  }
+});
 const PORT = process.env.PORT || 3000;
 
 const s3 = new S3Client({
@@ -36,14 +46,16 @@ app.get('/upload', (req, res) => {
 
 app.post('/upload', upload.single('video'), async (req, res) => {
   try {
+    const fileStream = fs.createReadStream(req.file.path);
     await s3.send(
       new PutObjectCommand({
         Bucket: BUCKET,
         Key: req.file.originalname,
-        Body: req.file.buffer,
+        Body: fileStream,
         ContentType: req.file.mimetype
       })
     );
+    await fs.promises.unlink(req.file.path);
     res.redirect('/videos');
   } catch (err) {
     res.status(500).send('Upload failed');


### PR DESCRIPTION
## Summary
- store uploads on disk and limit file size before S3 transfer
- stream file data to S3 and clean up temporary upload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68920aebd1e8832ba5f3890c72f8852d