### PR TITLE
Add JudeOps camera uploader

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>JudeOps</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>JudeOps</h1>
+    <p class="tagline">Used to judge challenges</p>
+    <div class="mode-toggle">
+      <button id="cameraMode" class="active">Camera</button>
+      <button id="uploadMode">Upload</button>
+    </div>
+
+    <div id="cameraSection">
+      <video id="preview" autoplay muted playsinline class="rounded shadow"></video>
+      <div class="controls">
+        <button id="startBtn">Start Recording</button>
+        <button id="stopBtn" disabled>Stop &amp; Upload</button>
+      </div>
+    </div>
+
+    <div id="uploadSection" class="hidden">
+      <input type="file" id="fileInput" accept="video/*" class="rounded" />
+      <button id="uploadFileBtn">Upload</button>
+    </div>
+
+    <p><a href="/videos">View Uploaded Videos</a></p>
+  </div>
+  <script src="/script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,85 @@
+const cameraMode = document.getElementById('cameraMode');
+const uploadMode = document.getElementById('uploadMode');
+const cameraSection = document.getElementById('cameraSection');
+const uploadSection = document.getElementById('uploadSection');
+const startBtn = document.getElementById('startBtn');
+const stopBtn = document.getElementById('stopBtn');
+const preview = document.getElementById('preview');
+const fileInput = document.getElementById('fileInput');
+const uploadFileBtn = document.getElementById('uploadFileBtn');
+
+let stream;
+let recorder;
+let chunks = [];
+
+function setMode(mode) {
+  if (mode === 'camera') {
+    cameraSection.classList.remove('hidden');
+    uploadSection.classList.add('hidden');
+    cameraMode.classList.add('active');
+    uploadMode.classList.remove('active');
+  } else {
+    uploadSection.classList.remove('hidden');
+    cameraSection.classList.add('hidden');
+    uploadMode.classList.add('active');
+    cameraMode.classList.remove('active');
+  }
+}
+
+cameraMode.addEventListener('click', () => setMode('camera'));
+uploadMode.addEventListener('click', () => setMode('upload'));
+
+async function initCamera() {
+  if (!stream) {
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+      preview.srcObject = stream;
+    } catch (err) {
+      console.error('camera init failed', err);
+      return false;
+    }
+  }
+  return true;
+}
+
+startBtn.addEventListener('click', async () => {
+  const ok = await initCamera();
+  if (!ok) return;
+  chunks = [];
+  recorder = new MediaRecorder(stream);
+  recorder.ondataavailable = e => {
+    // some browsers fire an empty Blob event at start; guard against it
+    if (e.data && e.data.size > 0) {
+      chunks.push(e.data);
+    }
+  };
+  recorder.onstop = uploadRecording;
+  recorder.start();
+  startBtn.disabled = true;
+  stopBtn.disabled = false;
+});
+
+stopBtn.addEventListener('click', () => {
+  recorder.stop();
+  startBtn.disabled = false;
+  stopBtn.disabled = true;
+});
+
+async function uploadRecording() {
+  if (!chunks.length) return;
+  const blob = new Blob(chunks, { type: 'video/webm' });
+  const file = new File([blob], 'recording.webm', { type: 'video/webm' });
+  const fd = new FormData();
+  fd.append('video', file);
+  await fetch('/upload', { method: 'POST', body: fd });
+  window.location.href = '/videos';
+}
+
+uploadFileBtn.addEventListener('click', async () => {
+  const file = fileInput.files[0];
+  if (!file) return;
+  const fd = new FormData();
+  fd.append('video', file);
+  await fetch('/upload', { method: 'POST', body: fd });
+  window.location.href = '/videos';
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,75 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #f0f2f5;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.container {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  width: 90%;
+  max-width: 500px;
+}
+
+.tagline {
+  margin-top: -0.5rem;
+  margin-bottom: 1rem;
+  color: #555;
+}
+
+.mode-toggle button {
+  margin: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  background: #e0e0e0;
+}
+
+.mode-toggle button.active {
+  background: #007bff;
+  color: #fff;
+}
+
+video {
+  width: 100%;
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  margin-bottom: 1rem;
+}
+
+.controls button, #uploadFileBtn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+  margin: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.controls button:disabled,
+#uploadFileBtn:disabled {
+  background: #999;
+}
+
+.hidden {
+  display: none;
+}
+
+.video-card {
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  background: #fff;
+}


### PR DESCRIPTION
## Summary
- create interactive JudeOps web client with camera recording and file upload
- serve static assets and style video listings with rounded cards
- guard client recorder against empty data blobs to avoid console errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68920d29d968832bb4d38558f365fb9b